### PR TITLE
Exclude `macOS-latest-ghc-{8.10,9.0}` from build matrix. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ jobs:
           - '9.4'
           - '9.6'
           - '9.8'
+        exclude:
+          # TODO: https://github.com/haskell-actions/setup/issues/77
+          # To work around the above issue, we exclude the following versions:
+          - os: macOS-latest
+            ghc: '8.10'
+          - os: macOS-latest
+            ghc: '9.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As a temporary workaround for:
https://github.com/haskell-actions/setup/issues/77